### PR TITLE
Update Old Rogue URLs to Northstar

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -25,7 +25,7 @@ const App = ({ sdk, rogueUrl }) => {
         <TextLink
           target="_blank"
           icon="ChevronRight"
-          href={`${rogueUrl}/campaign-ids`}
+          href={`${rogueUrl}/campaigns`}
         >
           Find a campaign ID...
         </TextLink>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -9,7 +9,7 @@ import ErrorBoundary from './ErrorBoundary';
 import CampaignPreview from './CampaignPreview';
 import useContentfulField from '../hooks/useContentfulField';
 
-const App = ({ sdk, rogueUrl }) => {
+const App = ({ sdk, northstarUrl }) => {
   const [value, onChange] = useContentfulField(sdk);
 
   return (
@@ -25,13 +25,13 @@ const App = ({ sdk, rogueUrl }) => {
         <TextLink
           target="_blank"
           icon="ChevronRight"
-          href={`${rogueUrl}/campaigns`}
+          href={`${northstarUrl}/admin/campaigns`}
         >
           Find a campaign ID...
         </TextLink>
       </FieldGroup>
       <ErrorBoundary>
-        <CampaignPreview id={value} rogueUrl={rogueUrl} />
+        <CampaignPreview id={value} northstarUrl={northstarUrl} />
       </ErrorBoundary>
     </>
   );

--- a/src/components/CampaignPreview.js
+++ b/src/components/CampaignPreview.js
@@ -43,7 +43,7 @@ const CampaignPreview = props => {
       size="small"
       title={campaign.internalTitle}
       contentType={`${startDate} – ${endDate}`}
-      href={`${props.rogueUrl}/campaign-ids/${id}`}
+      href={`${props.rogueUrl}/campaigns/${id}`}
       target="_blank"
     />
   );

--- a/src/components/CampaignPreview.js
+++ b/src/components/CampaignPreview.js
@@ -43,7 +43,7 @@ const CampaignPreview = props => {
       size="small"
       title={campaign.internalTitle}
       contentType={`${startDate} – ${endDate}`}
-      href={`${props.rogueUrl}/campaigns/${id}`}
+      href={`${props.northstarUrl}/admin/campaigns/${id}`}
       target="_blank"
     />
   );

--- a/src/index.js
+++ b/src/index.js
@@ -15,21 +15,21 @@ const graphQLUrls = {
   master: 'https://graphql.dosomething.org',
 };
 
-const rogueUrls = {
-  dev: 'https://activity-dev.dosomething.org',
-  qa: 'https://activity-qa.dosomething.org',
-  master: 'https://activity.dosomething.org',
+const northstarUrls = {
+  dev: 'https://identity-dev.dosomething.org',
+  qa: 'https://identity-qa.dosomething.org',
+  master: 'https://identity.dosomething.org',
 };
 
 init(sdk => {
   // Choose the appropriate GraphQL environment to query:
   const environment = sdk.contentType.sys.environment.sys.id;
   const graphql = new GraphQLClient({ url: get(graphQLUrls, environment) });
-  const rogueUrl = get(rogueUrls, environment);
+  const northstarUrl = get(northstarUrls, environment);
 
   ReactDOM.render(
     <ClientContext.Provider value={graphql}>
-      <App sdk={sdk} rogueUrl={rogueUrl} />
+      <App sdk={sdk} northstarUrl={northstarUrl} />
     </ClientContext.Provider>,
     document.getElementById('root'),
   );


### PR DESCRIPTION
This PR updates the Rogue URLs to the new Northstar URLs. Most critically, it fixes a bug where the campaign preview link was using an outdated Rogue URL leading to a 404. (The other outdated URLs had redirects).

https://www.pivotaltracker.com/story/show/177580328

You can test this out on the development space [here](https://app.contentful.com/spaces/81iqaqpfd8fy/environments/dev/entries/6LQzMvDNQcYQYwso8qSkQ8)